### PR TITLE
add summation of events feature

### DIFF
--- a/lib/mc_forecast/simulation.rb
+++ b/lib/mc_forecast/simulation.rb
@@ -39,7 +39,7 @@ module McForecast
           sum: sum(steps, quantiles),
           # besides the total sum we may want to have a sum for multiples of our base period
           # (or week/month/quarter/year but that gets a bit complicated)
-          mean: steps.map { |trials| Rational(trials.sum || 0, trials.length) },
+          mean: steps.map { |trials| (trials.sum || 0).to_f / trials.length },
           quantiles: quantiles.zip(step_quantiles(quantiles, steps)).to_h
         }
       end
@@ -48,7 +48,8 @@ module McForecast
     def sum(steps, quantiles)
       sums = steps.transpose.map(&:sum) # gives a sum of this event, per trial
       {
-        mean: Rational(sums.sum || 0, steps[0].length), # should we return floats instead?
+        mean: (sums.sum || 0).to_f / steps[0].length,
+        # sort all of the sums, and take the elements closest to the chosen quantiles, and then make a nice hash
         quantiles: quantiles.zip(sums.sort.values_at(*quantile_indices(steps[0].length, quantiles))).to_h
       }
     end

--- a/lib/mc_forecast/simulation.rb
+++ b/lib/mc_forecast/simulation.rb
@@ -24,33 +24,50 @@ module McForecast
 
     # Return an analysis of the events, containing:
     # { event_name:
-    #   { mean: [...], # per step
+    #   {
+    #     sum: { mean: ...,
+    #            quantiles:
+    #              { 0.025: ..., 0.975: ... }},
+    #     mean: [...], # per step
     #     quantiles:
     #      { 0.025: [...],
     #        0.975: [...]
     # }}}
     def analyze(events, quantiles)
       events.transform_values do |steps| # array(steps) of arrays(trials)
-        a = if quantiles.any?
-              # only need to sort if we request answers on any quantiles
-              steps.map do |trials|
-                # could avoid sorting with some creativity, but probably fine for our data lengths so far
-                trials.sort.values_at(*quantile_indices(trials.length, quantiles))
-              end.transpose # a[step][]
-            else
-              []
-            end
-
         {
+          sum: sum(steps, quantiles),
+          # besides the total sum we may want to have a sum for multiples of our base period
+          # (or week/month/quarter/year but that gets a bit complicated)
           mean: steps.map { |trials| Rational(trials.sum || 0, trials.length) },
-          quantiles: quantiles.zip(a).to_h
+          quantiles: quantiles.zip(step_quantiles(quantiles, steps)).to_h
         }
       end
     end
 
-    def quantile_indices(n_trials, quantiles)
+    def sum(steps, quantiles)
+      sums = steps.transpose.map(&:sum) # gives a sum of this event, per trial
+      {
+        mean: Rational(sums.sum || 0, steps[0].length), # should we return floats instead?
+        quantiles: quantiles.zip(sums.sort.values_at(*quantile_indices(steps[0].length, quantiles))).to_h
+      }
+    end
+
+    def step_quantiles(quantiles, steps)
+      if quantiles.any?
+        # only need to sort if we request answers on any quantiles
+        steps.map do |trials|
+          # could avoid sorting with some creativity, but probably fine for our data lengths so far
+          trials.sort.values_at(*quantile_indices(trials.length, quantiles))
+        end.transpose # a[step][]
+      else
+        []
+      end
+    end
+
+    def quantile_indices(count, quantiles)
       quantiles.map do |q|
-        (q * (n_trials - 1)).round.to_i.clamp(0, n_trials - 1)
+        (q * (count - 1)).round.to_i.clamp(0, count - 1)
       end
     end
   end

--- a/lib/mc_forecast/version.rb
+++ b/lib/mc_forecast/version.rb
@@ -1,3 +1,3 @@
 module McForecast
-  VERSION = "0.1.1".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/test/mc_forecast/events_test.rb
+++ b/test/mc_forecast/events_test.rb
@@ -27,4 +27,40 @@ class EventsTest < Minitest::Test
     assert_in_delta(0.025, e[:rand][:quantiles][0.025][0], 0.03)
     assert_in_delta(0.975, e[:rand][:quantiles][0.975][0], 0.03)
   end
+
+  def test_sums_one
+    n_steps = ((rand * 30) + 10).to_i
+    e = McForecast::Simulation.new.run(steps: n_steps) do |_state, _step, _trial|
+      events = {}
+      events[:one] = 1
+
+      [nil, events]
+    end
+
+    assert_in_delta(n_steps, e[:one][:sum][:mean], 0.03)
+    assert_in_delta(n_steps, e[:one][:sum][:quantiles][0.025], 0.03)
+    assert_in_delta(n_steps, e[:one][:sum][:quantiles][0.975], 0.03)
+  end
+
+  def test_sums_rand
+    n_steps = 12
+    e = McForecast::Simulation.new.run(steps: n_steps) do |_state, _step, _trial|
+      events = {}
+      events[:rand] = rand
+
+      [nil, events]
+    end
+
+    # we do 1000 trials
+    assert_in_delta(6, e[:rand][:sum][:mean], 0.1)
+    # this gets a bit hairy:
+    # see https://stats.stackexchange.com/questions/41467/consider-the-sum-of-n-uniform-distributions-on-0-1-or-z-n-why-does-the
+    # given enough samples we'll just assume it's like a gaussian
+    # see https://www.johndcook.com/blog/2009/02/12/sums-of-uniform-random-values/ to get to these numbers
+    # and the steps were chosen to make it one centered at 6, with variance 1 (and thus sigma 1)
+    # use https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
+    # the below does not work to a very high accuracy, and we may have to do some math to get more accurate values
+    assert_in_delta(4, e[:rand][:sum][:quantiles][0.025], 0.2)
+    assert_in_delta(8, e[:rand][:sum][:quantiles][0.975], 0.2)
+  end
 end

--- a/test/mc_forecast/events_test.rb
+++ b/test/mc_forecast/events_test.rb
@@ -60,7 +60,7 @@ class EventsTest < Minitest::Test
     # and the steps were chosen to make it one centered at 6, with variance 1 (and thus sigma 1)
     # use https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule
     # the below does not work to a very high accuracy, and we may have to do some math to get more accurate values
-    assert_in_delta(4, e[:rand][:sum][:quantiles][0.025], 0.2)
-    assert_in_delta(8, e[:rand][:sum][:quantiles][0.975], 0.2)
+    assert_in_delta(4, e[:rand][:sum][:quantiles][0.025], 0.3)
+    assert_in_delta(8, e[:rand][:sum][:quantiles][0.975], 0.3)
   end
 end


### PR DESCRIPTION
Calculate not just the distribution of events on any individual step, but also the distribution of total events over the entire simulation.

We may want to do subset sums in the future, but let's not for now.
